### PR TITLE
excluding previous versions implementation

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -27,5 +27,6 @@ jobs:
       run: |
         mkdir -p docs
         touch docs/.nojekyll
-        make gendoc
+        cp src/docs/*md docs
+        poetry run gen-doc -d docs --template-directory src/doc_templates src/linkml/include_schema.yaml        
         poetry run mkdocs gh-deploy

--- a/Makefile
+++ b/Makefile
@@ -81,35 +81,9 @@ $(PYMODEL):
 $(DOCDIR):
 	mkdir -p $@
 
-#gendoc: $(DOCDIR)
-#	cp $(SRC)/docs/*md $(DOCDIR) ; \
-#	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH)
-
-update-docs:
-	cp $(SRC)/docs/about.md $(DOCDIR)/about.md
-	@echo "Updated docs/about.md from src/docs/about.md"
-
-# Include update-docs target in gendoc target
 gendoc: $(DOCDIR)
-	@initial_branch=$$(git branch --show-current); \
-	latest_version=$$(git tag | sort -V | tail -n 1); \
-	for version in $$(git tag | sort -V); do \
-		if [ "$$version" = "$$latest_version" ]; then \
-			echo "Generating documentation for the current version: $$version"; \
-			git checkout $$version; \
-			$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH); \
-			cp $(SRC)/docs/*md $(DOCDIR); \
-		elif [ ! -d $(DOCDIR)/$$version ]; then \
-			echo "Generating documentation for version: $$version"; \
-			git checkout $$version; \
-			$(RUN) gen-doc -d $(DOCDIR)/$$version --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH); \
-			cp $(SRC)/docs/*md $(DOCDIR)/$$version; \
-		else \
-			echo "Documentation for $$version already exists, skipping."; \
-		fi; \
-	done; \
-	git checkout $$initial_branch
-	update-docs
+	cp $(SRC)/docs/*md $(DOCDIR) ; \
+	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH)
 
 testdoc: gendoc serve
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,6 @@ plugins:
 nav:
   - Index: index.md
   - About: about.md
-  - Previous Releases:
-      - Version 2.2.0: v2.2.0/index.md
-      - Version 2.1.0: v2.1.0/index.md
+
 site_url: https://include-dcc.github.io/include-linkml/
 repo_url: https://github.com/include-dcc/include-linkml/


### PR DESCRIPTION
Bringing in previous versions seems a bit harder than expected, so we will exclude it for now.