### PR TITLE
Fix erdiagram auto doc

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,14 +23,11 @@ jobs:
     - name: Install dependencies.
       run: poetry install -E docs
 
-    - name: Generate ER Diagram.
-      run: |
-        poetry run gen-erdiagram src/linkml/include_schema.yaml > src/docs/erdiagram.md
-    
     - name: Build documentation.
       run: |
         mkdir -p docs
         touch docs/.nojekyll
         cp src/docs/*md docs
+        poetry run gen-erdiagram src/linkml/include_schema.yaml > docs/erdiagram.md
         poetry run gen-doc -d docs --template-directory src/doc_templates src/linkml/include_schema.yaml        
         poetry run mkdocs gh-deploy


### PR DESCRIPTION
Related to #265

Attempt 1: saving erdiagram.md in docs folder instead of src/docs of main branch. 